### PR TITLE
Fix parameter typo in GridTensor.reshape_tensor

### DIFF
--- a/rl_adn/utility/grid.py
+++ b/rl_adn/utility/grid.py
@@ -408,7 +408,7 @@ class GridTensor:
 
         return M_big, H_big
 
-    def reshape_tensor(sefl, tensor_array):
+    def reshape_tensor(self, tensor_array):
         """
         Reshapes a tensor array for power flow calculations.
 


### PR DESCRIPTION
## Summary
- correct parameter name in `GridTensor.reshape_tensor`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683f45b0246c832bbe661e86c05262a1