### PR TITLE
Convert powerflow scripts to pytest tests

### DIFF
--- a/tests/123_node_network_powerflow_test.py
+++ b/tests/123_node_network_powerflow_test.py
@@ -1,68 +1,75 @@
 import os
 import time
 import numpy as np
-import pandas as pd
 import pandapower as pp
 
 from rl_adn.utility.grid import GridTensor
 from rl_adn.utility.utils import create_pandapower_net
 
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../rl_adn', 'data_sources'))
+CONFIG = {
+    'branch_info_file': os.path.join(ROOT_DIR, 'network_data/node_123', 'Lines_123.csv'),
+    'bus_info_file': os.path.join(ROOT_DIR, 'network_data/node_123', 'Nodes_123.csv'),
+    'vm_pu': 1.0,
+    's_base': 1000,
+}
 
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../rl_adn', 'data_sources'))
-config={
-            'branch_info_file': os.path.join(root_dir, 'network_data/node_123', 'Lines_123.csv'),
-            'bus_info_file': os.path.join(root_dir, 'network_data/node_123', 'Nodes_123.csv'),
-            'vm_pu': 1.0,
-            's_base': 1000
-        }
-branch_info = pd.read_csv(config['branch_info_file'], encoding='utf-8')
-bus_info = pd.read_csv(config['bus_info_file'], encoding='utf-8')
+P_FILE = np.array([
+    387.09, 0., 387.09, 387.09, 0., 0., 387.09, 387.09,
+    0., 387.09, 230.571, 121.176, 121.176, 121.176, 22.7205, 387.09,
+    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
+    387.09, 0., 387.09, 387.09, 0., 0., 387.09, 387.09,
+    0., 387.09, 230.571, 121.176, 121.176, 121.176, 22.7205, 387.09,
+    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
+    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
+    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
+    0., 387.09, 230.571, 121.176, 121.176, 121.176, 22.7205, 387.09,
+    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
+    387.09, 0., 387.09, 387.09, 0., 0., 387.09, 387.09,
+    0., 387.09, 230.571, 121.176, 121.176, 121.176, 22.7205, 387.09,
+    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
+    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
+    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
+    387.09, 387.09,
+])
 
-network = GridTensor(node_file_path=config['bus_info_file'],
-                     lines_file_path=config['branch_info_file'])
-Ybus = network._make_y_bus().toarray()
-P_file = np.array([387.09, 0., 387.09, 387.09, 0., 0., 387.09, 387.09,
-                   0., 387.09, 230.571, 121.176, 121.176, 121.176, 22.7205, 387.09,
-                   387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
-                   387.09, 0., 387.09, 387.09, 0., 0., 387.09, 387.09,
-                   0., 387.09, 230.571, 121.176, 121.176, 121.176, 22.7205, 387.09,
-                   387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
-                    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
-                    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
-                   0., 387.09, 230.571, 121.176, 121.176, 121.176, 22.7205, 387.09,
-                   387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
-                   387.09, 0., 387.09, 387.09, 0., 0., 387.09, 387.09,
-                   0., 387.09, 230.571, 121.176, 121.176, 121.176, 22.7205, 387.09,
-                   387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
-                    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
-                    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
-                   387.09, 387.09,
-                   ])
-network.Q_file = np.zeros(122)
-start_time_laurent = time.time()
-solution_laurent = network.run_pf(active_power=P_file)
-time_laurent = time.time() - start_time_laurent
 
-net = create_pandapower_net(config)
-for bus_index in net.load.bus.index:
-    if bus_index == 0:
-        net.load.p_mw[bus_index] = 0
-        net.load.q_mvar[bus_index] = 0
-    else:
-        net.load.p_mw[bus_index] = P_file[bus_index - 1] / 1000
-        net.load.q_mvar[bus_index - 1] = 0
+def _run_powerflow(config, p_file):
+    network = GridTensor(node_file_path=config['bus_info_file'],
+                         lines_file_path=config['branch_info_file'])
+    network.Q_file = np.zeros(len(p_file))
 
-start_time_panda = time.time()
-pp.runpp(net,algorithm='nr',max_iteration=100)
-time_panda = time.time() - start_time_panda
+    start_laurent = time.time()
+    solution_laurent = network.run_pf(active_power=p_file)
+    time_laurent = time.time() - start_laurent
 
-v_laurent = solution_laurent["v"]
-v_laurent = np.insert(v_laurent, 0, 1)
-v_laurent_magnitude = abs(v_laurent)
+    net = create_pandapower_net(config)
+    for bus_index in net.load.bus.index:
+        if bus_index == 0:
+            net.load.p_mw[bus_index] = 0
+            net.load.q_mvar[bus_index] = 0
+        else:
+            net.load.p_mw[bus_index] = p_file[bus_index - 1] / 1000
+            net.load.q_mvar[bus_index - 1] = 0
 
-v_real_panda = net.res_bus["vm_pu"].values * np.cos(np.deg2rad(net.res_bus["va_degree"].values))
-v_img_panda = net.res_bus["vm_pu"].values * np.sin(np.deg2rad(net.res_bus["va_degree"].values))
-v_panda = v_real_panda + 1j * v_img_panda
-v_panda_magnitude = abs(v_panda)
+    start_panda = time.time()
+    pp.runpp(net, algorithm='nr', max_iteration=100)
+    time_panda = time.time() - start_panda
 
-print('error',v_panda_magnitude-v_laurent_magnitude)
+    v_laurent = solution_laurent["v"]
+    v_laurent = np.insert(v_laurent, 0, 1)
+    v_laurent_mag = np.abs(v_laurent)
+
+    v_real_panda = net.res_bus["vm_pu"].values * np.cos(np.deg2rad(net.res_bus["va_degree"].values))
+    v_img_panda = net.res_bus["vm_pu"].values * np.sin(np.deg2rad(net.res_bus["va_degree"].values))
+    v_panda = v_real_panda + 1j * v_img_panda
+    v_panda_mag = np.abs(v_panda)
+
+    error = np.mean(np.abs(v_panda_mag - v_laurent_mag))
+    return error, time_laurent, time_panda
+
+
+def test_powerflow_123_node():
+    error, t_laurent, t_panda = _run_powerflow(CONFIG, P_FILE)
+    assert error < 1e-3
+    assert t_laurent < t_panda

--- a/tests/25_node_network_powerflow_test.py
+++ b/tests/25_node_network_powerflow_test.py
@@ -1,74 +1,63 @@
 import os
 import time
 import numpy as np
-import pandas as pd
 import pandapower as pp
 
 from rl_adn.utility.grid import GridTensor
 from rl_adn.utility.utils import create_pandapower_net
 
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../rl_adn', 'data_sources'))
-config={
-            'branch_info_file': os.path.join(root_dir, 'network_data/node_25', 'Lines_25.csv'),
-            'bus_info_file': os.path.join(root_dir, 'network_data/node_25', 'Nodes_25.csv'),
-            'vm_pu': 1.0,
-            's_base': 1000
-        }
-branch_info = pd.read_csv(config['branch_info_file'], encoding='utf-8')
-bus_info = pd.read_csv(config['bus_info_file'], encoding='utf-8')
 
-network = GridTensor(node_file_path=config['bus_info_file'],
-                     lines_file_path=config['branch_info_file'])
-Ybus = network._make_y_bus().toarray()
-P_file = np.array([387.09, 0., 387.09, 387.09, 0., 0., 387.09, 387.09,
-                   0., 387.09, 230.571, 121.176, 121.176, 121.176, 22.7205, 387.09,
-                   387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
-                   ])
-network.Q_file = np.zeros(24)
-num_runs = 100
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../rl_adn', 'data_sources'))
+CONFIG = {
+    'branch_info_file': os.path.join(ROOT_DIR, 'network_data/node_25', 'Lines_25.csv'),
+    'bus_info_file': os.path.join(ROOT_DIR, 'network_data/node_25', 'Nodes_25.csv'),
+    'vm_pu': 1.0,
+    's_base': 1000,
+}
+
+P_FILE = np.array([
+    387.09, 0., 387.09, 387.09, 0., 0., 387.09, 387.09,
+    0., 387.09, 230.571, 121.176, 121.176, 121.176, 22.7205, 387.09,
+    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
+])
 
 
+def _run_powerflow(config, p_file):
+    network = GridTensor(node_file_path=config['bus_info_file'],
+                         lines_file_path=config['branch_info_file'])
+    network.Q_file = np.zeros(len(p_file))
 
+    start_laurent = time.time()
+    solution_laurent = network.run_pf(active_power=p_file)
+    time_laurent = time.time() - start_laurent
 
-start_time_laurent = time.time()
-for i in range(num_runs):
-    solution_laurent = network.run_pf(active_power=P_file)
-time_laurent = time.time() - start_time_laurent
+    net = create_pandapower_net(config)
+    for bus_index in net.load.bus.index:
+        if bus_index == 0:
+            net.load.p_mw[bus_index] = 0
+            net.load.q_mvar[bus_index] = 0
+        else:
+            net.load.p_mw[bus_index] = p_file[bus_index - 1] / 1000
+            net.load.q_mvar[bus_index - 1] = 0
 
-net = create_pandapower_net(config)
-
-for bus_index in net.load.bus.index:
-    if bus_index == 0:
-        net.load.p_mw[bus_index] = 0
-        net.load.q_mvar[bus_index] = 0
-    else:
-        net.load.p_mw[bus_index] = P_file[bus_index - 1] / 1000
-        net.load.q_mvar[bus_index - 1] = 0
-
-start_time_panda = time.time()
-for i in range(num_runs):
+    start_panda = time.time()
     pp.runpp(net)
-time_panda = time.time() - start_time_panda
+    time_panda = time.time() - start_panda
 
-v_laurent = solution_laurent["v"]
-v_34_laurent = np.insert(v_laurent, 0, 1)
-v_laurent_magnitude = abs(v_34_laurent)
+    v_laurent = solution_laurent["v"]
+    v_laurent = np.insert(v_laurent, 0, 1)
+    v_laurent_mag = np.abs(v_laurent)
 
-v_real_panda = net.res_bus["vm_pu"].values * np.cos(np.deg2rad(net.res_bus["va_degree"].values))
-v_img_panda = net.res_bus["vm_pu"].values * np.sin(np.deg2rad(net.res_bus["va_degree"].values))
-v_panda = v_real_panda + 1j * v_img_panda
-v_panda_magnitude = abs(v_panda)
-time_panda_ms = time_panda * 1000
-time_laurent_ms = time_laurent * 1000
+    v_real_panda = net.res_bus["vm_pu"].values * np.cos(np.deg2rad(net.res_bus["va_degree"].values))
+    v_img_panda = net.res_bus["vm_pu"].values * np.sin(np.deg2rad(net.res_bus["va_degree"].values))
+    v_panda = v_real_panda + 1j * v_img_panda
+    v_panda_mag = np.abs(v_panda)
 
-time_panda_ns = time_panda * 1e9
-time_laurent_ns = time_laurent * 1e9
-print('error percentage',np.mean((v_panda_magnitude-v_laurent_magnitude)))
-print('time used by pandapower: {:.6f} seconds'.format(time_panda/num_runs))
-print('time used by laurent power: {:.6f} seconds'.format(time_laurent/num_runs))
-# Print the times
-print('time used by pandapower: {:.2f} ms'.format(time_panda_ms/num_runs))
-print('time used by laurent power: {:.2f} ms'.format(time_laurent_ms/num_runs))
+    error = np.mean(np.abs(v_panda_mag - v_laurent_mag))
+    return error, time_laurent, time_panda
 
-print('time used by pandapower: {:.2f} ns'.format(time_panda_ns/num_runs))
-print('time used by laurent power: {:.2f} ns'.format(time_laurent_ns/num_runs))
+
+def test_powerflow_25_node():
+    error, t_laurent, t_panda = _run_powerflow(CONFIG, P_FILE)
+    assert error < 1e-3
+    assert t_laurent < t_panda

--- a/tests/34_node_network_powerflow_test.py
+++ b/tests/34_node_network_powerflow_test.py
@@ -1,75 +1,64 @@
-from rl_adn.utility.grid import GridTensor
-from rl_adn.utility.utils import create_pandapower_net
 import os
 import time
 import numpy as np
-import pandas as pd
 import pandapower as pp
 
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../rl_adn', 'data_sources'))
-config={
-            'branch_info_file': os.path.join(root_dir, 'network_data/node_34', 'Lines_34.csv'),
-            'bus_info_file': os.path.join(root_dir, 'network_data/node_34', 'Nodes_34.csv'),
-            'vm_pu': 1.0,
-            's_base': 1000
-        }
-branch_info = pd.read_csv(config['branch_info_file'], encoding='utf-8')
-bus_info = pd.read_csv(config['bus_info_file'], encoding='utf-8')
+from rl_adn.utility.grid import GridTensor
+from rl_adn.utility.utils import create_pandapower_net
 
-network = GridTensor(node_file_path=config['bus_info_file'],
-                     lines_file_path=config['branch_info_file'])
-Ybus = network._make_y_bus().toarray()
-P_file = np.array([387.09, 0., 387.09, 387.09, 0., 0., 387.09, 387.09,
-                   0., 387.09, 230.571, 121.176, 121.176, 121.176, 22.7205, 387.09,
-                   387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
-                   387.09, 230.571, 126.225, 126.225, 126.225, 95.931, 95.931, 95.931,
-                   95.931])
-network.Q_file = np.zeros(33)
-num_runs = 100
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../rl_adn', 'data_sources'))
+CONFIG = {
+    'branch_info_file': os.path.join(ROOT_DIR, 'network_data/node_34', 'Lines_34.csv'),
+    'bus_info_file': os.path.join(ROOT_DIR, 'network_data/node_34', 'Nodes_34.csv'),
+    'vm_pu': 1.0,
+    's_base': 1000,
+}
+
+P_FILE = np.array([
+    387.09, 0., 387.09, 387.09, 0., 0., 387.09, 387.09,
+    0., 387.09, 230.571, 121.176, 121.176, 121.176, 22.7205, 387.09,
+    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
+    387.09, 230.571, 126.225, 126.225, 126.225, 95.931, 95.931, 95.931,
+    95.931,
+])
 
 
+def _run_powerflow(config, p_file):
+    network = GridTensor(node_file_path=config['bus_info_file'],
+                         lines_file_path=config['branch_info_file'])
+    network.Q_file = np.zeros(len(p_file))
 
+    start_laurent = time.time()
+    solution_laurent = network.run_pf(active_power=p_file)
+    time_laurent = time.time() - start_laurent
 
-start_time_laurent = time.time()
-for i in range(num_runs):
-    solution_laurent = network.run_pf(active_power=P_file)
-time_laurent = time.time() - start_time_laurent
+    net = create_pandapower_net(config)
+    for bus_index in net.load.bus.index:
+        if bus_index == 0:
+            net.load.p_mw[bus_index] = 0
+            net.load.q_mvar[bus_index] = 0
+        else:
+            net.load.p_mw[bus_index] = p_file[bus_index - 1] / 1000
+            net.load.q_mvar[bus_index - 1] = 0
 
-net = create_pandapower_net(config)
-
-for bus_index in net.load.bus.index:
-    if bus_index == 0:
-        net.load.p_mw[bus_index] = 0
-        net.load.q_mvar[bus_index] = 0
-    else:
-        net.load.p_mw[bus_index] = P_file[bus_index - 1] / 1000
-        net.load.q_mvar[bus_index - 1] = 0
-
-start_time_panda = time.time()
-for i in range(num_runs):
+    start_panda = time.time()
     pp.runpp(net)
-time_panda = time.time() - start_time_panda
+    time_panda = time.time() - start_panda
 
-v_laurent = solution_laurent["v"]
-v_34_laurent = np.insert(v_laurent, 0, 1)
-v_laurent_magnitude = abs(v_34_laurent)
+    v_laurent = solution_laurent["v"]
+    v_laurent = np.insert(v_laurent, 0, 1)
+    v_laurent_mag = np.abs(v_laurent)
 
-v_real_panda = net.res_bus["vm_pu"].values * np.cos(np.deg2rad(net.res_bus["va_degree"].values))
-v_img_panda = net.res_bus["vm_pu"].values * np.sin(np.deg2rad(net.res_bus["va_degree"].values))
-v_panda = v_real_panda + 1j * v_img_panda
-v_panda_magnitude = abs(v_panda)
-time_panda_ms = time_panda * 1000
-time_laurent_ms = time_laurent * 1000
+    v_real_panda = net.res_bus["vm_pu"].values * np.cos(np.deg2rad(net.res_bus["va_degree"].values))
+    v_img_panda = net.res_bus["vm_pu"].values * np.sin(np.deg2rad(net.res_bus["va_degree"].values))
+    v_panda = v_real_panda + 1j * v_img_panda
+    v_panda_mag = np.abs(v_panda)
 
-# Convert to nanoseconds
-time_panda_ns = time_panda * 1e9
-time_laurent_ns = time_laurent * 1e9
-print('error percentage',np.mean((v_panda_magnitude-v_laurent_magnitude)))
-print('time used by pandapower: {:.6f} seconds'.format(time_panda/num_runs))
-print('time used by laurent power: {:.6f} seconds'.format(time_laurent/num_runs))
-# Print the times
-print('time used by pandapower: {:.2f} ms'.format(time_panda_ms/num_runs))
-print('time used by laurent power: {:.2f} ms'.format(time_laurent_ms/num_runs))
+    error = np.mean(np.abs(v_panda_mag - v_laurent_mag))
+    return error, time_laurent, time_panda
 
-print('time used by pandapower: {:.2f} ns'.format(time_panda_ns/num_runs))
-print('time used by laurent power: {:.2f} ns'.format(time_laurent_ns/num_runs))
+
+def test_powerflow_34_node():
+    error, t_laurent, t_panda = _run_powerflow(CONFIG, P_FILE)
+    assert error < 1e-3
+    assert t_laurent < t_panda

--- a/tests/69_node_network_powerflow_test.py
+++ b/tests/69_node_network_powerflow_test.py
@@ -1,81 +1,68 @@
 import os
 import time
 import numpy as np
-import pandas as pd
 import pandapower as pp
 
 from rl_adn.utility.grid import GridTensor
 from rl_adn.utility.utils import create_pandapower_net
 
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../rl_adn', 'data_sources'))
+CONFIG = {
+    'branch_info_file': os.path.join(ROOT_DIR, 'network_data/node_69', 'Lines_69.csv'),
+    'bus_info_file': os.path.join(ROOT_DIR, 'network_data/node_69', 'Nodes_69.csv'),
+    'vm_pu': 1.0,
+    's_base': 1000,
+}
 
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../rl_adn', 'data_sources'))
-config={
-            'branch_info_file': os.path.join(root_dir, 'network_data/node_69', 'Lines_69.csv'),
-            'bus_info_file': os.path.join(root_dir, 'network_data/node_69', 'Nodes_69.csv'),
-            'vm_pu': 1.0,
-            's_base': 1000
-        }
-branch_info = pd.read_csv(config['branch_info_file'], encoding='utf-8')
-bus_info = pd.read_csv(config['bus_info_file'], encoding='utf-8')
-
-network = GridTensor(node_file_path=config['bus_info_file'],
-                     lines_file_path=config['branch_info_file'])
-Ybus = network._make_y_bus().toarray()
-P_file = np.array([387.09, 0., 387.09, 387.09, 0., 0., 387.09, 387.09,
-                   0., 387.09, 230.571, 121.176, 121.176, 121.176, 22.7205, 387.09,
-                   387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
-                   387.09, 0., 387.09, 387.09, 0., 0., 387.09, 387.09,
-                   0., 387.09, 230.571, 121.176, 121.176, 121.176, 22.7205, 387.09,
-                   387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
-                    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
-                    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
-                   387.09, 387.09, 387.09, 387.09,
-                   ])
-network.Q_file = np.zeros(68)
-num_runs = 100
+P_FILE = np.array([
+    387.09, 0., 387.09, 387.09, 0., 0., 387.09, 387.09,
+    0., 387.09, 230.571, 121.176, 121.176, 121.176, 22.7205, 387.09,
+    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
+    387.09, 0., 387.09, 387.09, 0., 0., 387.09, 387.09,
+    0., 387.09, 230.571, 121.176, 121.176, 121.176, 22.7205, 387.09,
+    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
+    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
+    387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09, 387.09,
+    387.09, 387.09, 387.09, 387.09,
+])
 
 
+def _run_powerflow(config, p_file):
+    network = GridTensor(node_file_path=config['bus_info_file'],
+                         lines_file_path=config['branch_info_file'])
+    network.Q_file = np.zeros(len(p_file))
 
+    start_laurent = time.time()
+    solution_laurent = network.run_pf(active_power=p_file)
+    time_laurent = time.time() - start_laurent
 
-start_time_laurent = time.time()
-for i in range(num_runs):
-    solution_laurent = network.run_pf(active_power=P_file)
-time_laurent = time.time() - start_time_laurent
+    net = create_pandapower_net(config)
+    for bus_index in net.load.bus.index:
+        if bus_index == 0:
+            net.load.p_mw[bus_index] = 0
+            net.load.q_mvar[bus_index] = 0
+        else:
+            net.load.p_mw[bus_index] = p_file[bus_index - 1] / 1000
+            net.load.q_mvar[bus_index - 1] = 0
 
-net = create_pandapower_net(config)
-
-for bus_index in net.load.bus.index:
-    if bus_index == 0:
-        net.load.p_mw[bus_index] = 0
-        net.load.q_mvar[bus_index] = 0
-    else:
-        net.load.p_mw[bus_index] = P_file[bus_index - 1] / 1000
-        net.load.q_mvar[bus_index - 1] = 0
-
-start_time_panda = time.time()
-for i in range(num_runs):
+    start_panda = time.time()
     pp.runpp(net)
-time_panda = time.time() - start_time_panda
+    time_panda = time.time() - start_panda
 
-v_laurent = solution_laurent["v"]
-v_34_laurent = np.insert(v_laurent, 0, 1)
-v_laurent_magnitude = abs(v_34_laurent)
+    v_laurent = solution_laurent["v"]
+    v_laurent = np.insert(v_laurent, 0, 1)
+    v_laurent_mag = np.abs(v_laurent)
 
-v_real_panda = net.res_bus["vm_pu"].values * np.cos(np.deg2rad(net.res_bus["va_degree"].values))
-v_img_panda = net.res_bus["vm_pu"].values * np.sin(np.deg2rad(net.res_bus["va_degree"].values))
-v_panda = v_real_panda + 1j * v_img_panda
-v_panda_magnitude = abs(v_panda)
-time_panda_ms = time_panda * 1000
-time_laurent_ms = time_laurent * 1000
+    v_real_panda = net.res_bus["vm_pu"].values * np.cos(np.deg2rad(net.res_bus["va_degree"].values))
+    v_img_panda = net.res_bus["vm_pu"].values * np.sin(np.deg2rad(net.res_bus["va_degree"].values))
+    v_panda = v_real_panda + 1j * v_img_panda
+    v_panda_mag = np.abs(v_panda)
 
-time_panda_ns = time_panda * 1e9
-time_laurent_ns = time_laurent * 1e9
-print('error percentage',np.mean((v_panda_magnitude-v_laurent_magnitude)))
-print('time used by pandapower: {:.6f} seconds'.format(time_panda/num_runs))
-print('time used by laurent power: {:.6f} seconds'.format(time_laurent/num_runs))
-# Print the times
-print('time used by pandapower: {:.2f} ms'.format(time_panda_ms/num_runs))
-print('time used by laurent power: {:.2f} ms'.format(time_laurent_ms/num_runs))
+    error = np.mean(np.abs(v_panda_mag - v_laurent_mag))
+    return error, time_laurent, time_panda
 
-print('time used by pandapower: {:.2f} ns'.format(time_panda_ns/num_runs))
-print('time used by laurent power: {:.2f} ns'.format(time_laurent_ns/num_runs))
+
+def test_powerflow_69_node():
+    error, t_laurent, t_panda = _run_powerflow(CONFIG, P_FILE)
+    assert error < 1e-3
+    assert t_laurent < t_panda

--- a/tests/data_manager_test.py
+++ b/tests/data_manager_test.py
@@ -7,7 +7,7 @@ import os
 def test_GeneralPowerDataManager():
     # Generate sample data
     sample_data = {
-        'date_time': pd.date_range(start='2021-01-01', periods=24 * 30, freq='H'),
+        'date_time': pd.date_range(start='2021-01-01', periods=24 * 30, freq='H', tz='UTC'),
         'active_power_node_1': np.random.rand(24 * 30),
         'active_power_node_2': np.random.rand(24 * 30),
         'reactive_power_node_1': np.random.rand(24 * 30),
@@ -48,4 +48,3 @@ def test_GeneralPowerDataManager():
 
     # Cleanup
     os.remove(datapath)
-test_GeneralPowerDataManager()


### PR DESCRIPTION
## Summary
- replace print statements with assertions in powerflow tests
- remove manual invocations and create pytest test functions
- fix timezone handling in `data_manager_test`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d30dce7c0832bbf8558532a764872